### PR TITLE
Change how a timetable is represented

### DIFF
--- a/app/src/main/java/com/example/hwutimetable/TimetableView.kt
+++ b/app/src/main/java/com/example/hwutimetable/TimetableView.kt
@@ -7,7 +7,7 @@ import android.view.ViewGroup
 import android.widget.GridLayout
 import android.widget.LinearLayout
 import android.widget.TextView
-import com.example.hwutimetable.parser.TimetableItem
+import com.example.hwutimetable.parser.TimetableDay
 
 object TimetableView {
     internal class TextViewProperties(
@@ -17,7 +17,7 @@ object TimetableView {
         val gravity: Int?
     )
 
-    fun getTimetableItemView(context: Context, timetable: ArrayList<TimetableItem>): GridLayout {
+    fun getTimetableItemView(context: Context, timetable: TimetableDay): GridLayout {
         val gridLayout = createMainGridLayout(context)
         gridLayout.addView(
             createTimeTextView(context, "9:15"),

--- a/app/src/main/java/com/example/hwutimetable/ViewTimetable.kt
+++ b/app/src/main/java/com/example/hwutimetable/ViewTimetable.kt
@@ -14,6 +14,8 @@ import android.view.ViewGroup
 import android.widget.GridLayout
 import androidx.constraintlayout.widget.ConstraintSet
 import com.example.hwutimetable.parser.Parser
+import com.example.hwutimetable.parser.Timetable
+import com.example.hwutimetable.parser.TimetableDay
 import com.example.hwutimetable.parser.TimetableItem
 
 import kotlinx.android.synthetic.main.activity_view_timetable.*
@@ -65,17 +67,9 @@ class ViewTimetable : AppCompatActivity() {
         return super.onOptionsItemSelected(item)
     }
 
-    private fun getTimetable(title: String): ArrayList<List<TimetableItem>> {
+    private fun getTimetable(title: String): Timetable {
         val doc = DocumentHandler.getTimetable(baseContext, title)
-        val timetable = Parser(doc).parse()
-        val arrayList = arrayListOf(
-            timetable[0].toList(),
-            timetable[1].toList(),
-            timetable[2].toList(),
-            timetable[3].toList(),
-            timetable[4].toList()
-        )
-        return arrayList
+        return Parser(doc).parse()
     }
 
 
@@ -83,17 +77,13 @@ class ViewTimetable : AppCompatActivity() {
      * A [FragmentPagerAdapter] that returns a fragment corresponding to
      * one of the sections/tabs/pages.
      */
-    inner class SectionsPagerAdapter(fm: FragmentManager, private val timetable: ArrayList<List<TimetableItem>>) :
+    inner class SectionsPagerAdapter(fm: FragmentManager, private val timetable: Timetable) :
         FragmentPagerAdapter(fm, BEHAVIOR_RESUME_ONLY_CURRENT_FRAGMENT) {
 
         override fun getItem(position: Int): Fragment {
             // getItem is called to instantiate the fragment for the given page.
             // Return a PlaceholderFragment (defined as a static inner class below).
-            val itemsOfDay = ArrayList<TimetableItem>()
-            timetable[position].forEach {
-                itemsOfDay.add(it)
-            }
-            return PlaceholderFragment.newInstance(position + 1, itemsOfDay)
+            return PlaceholderFragment.newInstance(position + 1, timetable.days[position])
         }
 
         override fun getCount(): Int {
@@ -121,7 +111,7 @@ class ViewTimetable : AppCompatActivity() {
                 else -> throw IllegalArgumentException("ARG_SECTION_NUMBER must be between 0 and 4")
             }
 
-            val list = arguments?.getParcelableArrayList<TimetableItem>(ARG_SECTION_ITEMS)
+            val list = arguments?.getParcelable<TimetableDay>(ARG_SECTION_TIMETABLE)
                 ?: throw Exception("TimetableItem list must not be null")
 
             val timetableView = TimetableView.getTimetableItemView(context!!, list)
@@ -162,17 +152,17 @@ class ViewTimetable : AppCompatActivity() {
              * The fragment argument representing the timetable items for this
              * fragment.
              */
-            private val ARG_SECTION_ITEMS = "section_items"
+            private val ARG_SECTION_TIMETABLE = "section_items"
 
             /**
              * Returns a new instance of this fragment for the given section
              * number.
              */
-            fun newInstance(sectionNumber: Int, timetableItems: ArrayList<TimetableItem>): PlaceholderFragment {
+            fun newInstance(sectionNumber: Int, timetableDay: TimetableDay): PlaceholderFragment {
                 val fragment = PlaceholderFragment()
                 val args = Bundle()
                 args.putInt(ARG_SECTION_NUMBER, sectionNumber)
-                args.putParcelableArrayList(ARG_SECTION_ITEMS, timetableItems)
+                args.putParcelable(ARG_SECTION_TIMETABLE, timetableDay)
                 fragment.arguments = args
                 return fragment
             }

--- a/app/src/main/java/com/example/hwutimetable/parser/Hash.kt
+++ b/app/src/main/java/com/example/hwutimetable/parser/Hash.kt
@@ -7,6 +7,10 @@ import java.security.MessageDigest
 object Hash {
     fun compare(a: ByteArray, b: ByteArray) = a.contentEquals(b)
 
+    fun compare(a: Document, b: Document): Boolean {
+        return compare(get(a), get(b))
+    }
+
     fun get(document: Document): ByteArray {
         val messageDigest = MessageDigest.getInstance("SHA-256")
         return messageDigest.digest(document.outerHtml().toByteArray(StandardCharsets.UTF_8))

--- a/app/src/main/java/com/example/hwutimetable/parser/Hash.kt
+++ b/app/src/main/java/com/example/hwutimetable/parser/Hash.kt
@@ -1,0 +1,14 @@
+package com.example.hwutimetable.parser
+
+import org.jsoup.nodes.Document
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+
+object Hash {
+    fun compare(a: ByteArray, b: ByteArray) = a.contentEquals(b)
+
+    fun get(document: Document): ByteArray {
+        val messageDigest = MessageDigest.getInstance("SHA-256")
+        return messageDigest.digest(document.outerHtml().toByteArray(StandardCharsets.UTF_8))
+    }
+}

--- a/app/src/main/java/com/example/hwutimetable/parser/Parser.kt
+++ b/app/src/main/java/com/example/hwutimetable/parser/Parser.kt
@@ -10,13 +10,14 @@ import org.joda.time.LocalTime
  * @param table: Jsoup document with a Jsoup parser
  */
 class Parser(private val table: Document) {
-    val timetableItems : Array<MutableList<TimetableItem>> = arrayOf(
-        mutableListOf(),
-        mutableListOf(),
-        mutableListOf(),
-        mutableListOf(),
-        mutableListOf()
+    private val timetableDays: Array<TimetableDay> = arrayOf(
+        TimetableDay(Day.MONDAY, arrayListOf()),
+        TimetableDay(Day.TUESDAY, arrayListOf()),
+        TimetableDay(Day.WEDNESDAY, arrayListOf()),
+        TimetableDay(Day.THURSDAY, arrayListOf()),
+        TimetableDay(Day.FRIDAY, arrayListOf())
     )
+    private var timetable: Timetable? = null
 
     /**
      * Finds the rows of the day and returns the list of them
@@ -102,7 +103,7 @@ class Parser(private val table: Document) {
         val lecturer = lecInfo.selectFirst("td[align=left]").text()
         val type = lecInfo.selectFirst("td[align=right]").text()
 
-        timetableItems[dayIndex].add(TimetableItem(
+        timetableDays[dayIndex].items.add(TimetableItem(
             name = name,
             code = code,
             room = room,
@@ -155,7 +156,7 @@ class Parser(private val table: Document) {
      * Parses the timetable and return the timetable items
      * @return List of timetable items
      */
-    fun parse() : Array<MutableList<TimetableItem>> {
+    fun parse() : Timetable {
         if (!documentHasParser())
             throw ParserException("Document must have a Jsoup parser")
 
@@ -164,6 +165,12 @@ class Parser(private val table: Document) {
             addLecturesFromRows(rows, day)
         }
 
-        return timetableItems
+        // TODO: Find the hash of the timetable
+        timetable = Timetable("hash", timetableDays)
+        return timetable!!
+    }
+
+    fun getTimetable(): Timetable {
+        return timetable ?: throw ParserException("The timetable document has not been parsed!")
     }
 }

--- a/app/src/main/java/com/example/hwutimetable/parser/Parser.kt
+++ b/app/src/main/java/com/example/hwutimetable/parser/Parser.kt
@@ -166,7 +166,7 @@ class Parser(private val table: Document) {
         }
 
         // TODO: Find the hash of the timetable
-        timetable = Timetable("hash", timetableDays)
+        timetable = Timetable(Hash.get(this.table), timetableDays)
         return timetable!!
     }
 

--- a/app/src/main/java/com/example/hwutimetable/parser/Timetable.kt
+++ b/app/src/main/java/com/example/hwutimetable/parser/Timetable.kt
@@ -2,7 +2,7 @@ package com.example.hwutimetable.parser
 
 
 class Timetable(
-    val hash: String,
+    val hash: ByteArray,
     val days: Array<TimetableDay>
 ) {
     fun getTotalItems(): Int {

--- a/app/src/main/java/com/example/hwutimetable/parser/Timetable.kt
+++ b/app/src/main/java/com/example/hwutimetable/parser/Timetable.kt
@@ -1,0 +1,15 @@
+package com.example.hwutimetable.parser
+
+
+class Timetable(
+    val hash: String,
+    val days: Array<TimetableDay>
+) {
+    fun getTotalItems(): Int {
+        var items = 0
+        days.forEach {day ->
+            items += day.items.size
+        }
+        return items
+    }
+}

--- a/app/src/main/java/com/example/hwutimetable/parser/TimetableDay.kt
+++ b/app/src/main/java/com/example/hwutimetable/parser/TimetableDay.kt
@@ -1,0 +1,15 @@
+package com.example.hwutimetable.parser
+
+import android.os.Parcelable
+import kotlinx.android.parcel.Parcelize
+
+enum class Day(val index: Int) {
+    MONDAY(0),
+    TUESDAY(1),
+    WEDNESDAY(2),
+    THURSDAY(3),
+    FRIDAY(4)
+}
+
+@Parcelize
+data class TimetableDay(val day: Day, val items: ArrayList<TimetableItem>) : Parcelable

--- a/app/src/test/java/com/example/hwutimetable/parser/HashTest.kt
+++ b/app/src/test/java/com/example/hwutimetable/parser/HashTest.kt
@@ -8,10 +8,7 @@ class HashTest {
 
     @Test
     fun testSameFile() {
-        val parser = Parser(
-            org.jsoup.Jsoup.parse(File("src/test/sampleTimetables/tt1.html"), "UTF-8")
-        )
-        val hash = parser.parse().hash
-        assertTrue("The same hash", Hash.compare(hash, hash))
+        val doc = org.jsoup.Jsoup.parse(File("src/test/sampleTimetables/tt1.html"), "UTF-8")
+        assertTrue("The same hash", Hash.compare(doc, doc))
     }
 }

--- a/app/src/test/java/com/example/hwutimetable/parser/HashTest.kt
+++ b/app/src/test/java/com/example/hwutimetable/parser/HashTest.kt
@@ -1,0 +1,17 @@
+package com.example.hwutimetable.parser
+
+import org.junit.Test
+import org.junit.Assert.*
+import java.io.File
+
+class HashTest {
+
+    @Test
+    fun testSameFile() {
+        val parser = Parser(
+            org.jsoup.Jsoup.parse(File("src/test/sampleTimetables/tt1.html"), "UTF-8")
+        )
+        val hash = parser.parse().hash
+        assertTrue("The same hash", Hash.compare(hash, hash))
+    }
+}

--- a/app/src/test/java/com/example/hwutimetable/parser/ParserTest.kt
+++ b/app/src/test/java/com/example/hwutimetable/parser/ParserTest.kt
@@ -1,14 +1,16 @@
 package com.example.hwutimetable.parser
 
+import org.jsoup.nodes.Document
 import org.junit.Test
 import org.junit.Assert.*
 import org.junit.Before
 import java.io.File
 
 class ParserTest {
-    private val parser: Parser = Parser(
-        org.jsoup.Jsoup.parse(File("src/test/sampleTimetables/tt1.html"), "UTF-8")
+    private val document: Document = org.jsoup.Jsoup.parse(
+        File("src/test/sampleTimetables/tt1.html"), "UTF-8"
     )
+    private val parser: Parser = Parser(document)
 
     private var timetable: Timetable? = null
 
@@ -55,5 +57,16 @@ class ParserTest {
             assertTrue(expected[index].containsAll(codes))
             assertEquals(expected[index].size, timetable!!.days[index].items.size)
         }
+    }
+
+    /**
+     * Tests if the document hash is the same as parsed timetable hash
+     * (i.e. does the timetable get the hash of the document)
+     */
+    @Test
+    fun testHash() {
+        val docHash = Hash.get(document)
+        val timetableHash = timetable!!.hash
+        assertTrue(Hash.compare(docHash, timetableHash))
     }
 }

--- a/app/src/test/java/com/example/hwutimetable/parser/ParserTest.kt
+++ b/app/src/test/java/com/example/hwutimetable/parser/ParserTest.kt
@@ -10,9 +10,11 @@ class ParserTest {
         org.jsoup.Jsoup.parse(File("src/test/sampleTimetables/tt1.html"), "UTF-8")
     )
 
+    private var timetable: Timetable? = null
+
     @Before
     fun runParser() {
-        parser.parse()
+        timetable = parser.parse()
     }
 
     /**
@@ -26,8 +28,7 @@ class ParserTest {
     @Test
     fun testNumberOfItems() {
         // There are 15 timetable items in tt1.html
-        val lectures = parser.timetableItems.sumBy { it.size }
-        assertEquals(15, lectures)
+        assertEquals(15, timetable!!.getTotalItems())
     }
 
     @Test
@@ -35,7 +36,7 @@ class ParserTest {
         val expectedList = arrayOf(1, 3, 3, 4, 4)
 
         expectedList.forEachIndexed { index, expected ->
-            assertEquals(expected, parser.timetableItems[index].size)
+            assertEquals(expected, timetable!!.days[index].items.size)
         }
     }
 
@@ -49,10 +50,10 @@ class ParserTest {
             listOf("F29SO-S1", "F29AI-S1", "F29SO-S1", "F29SO-S1")  // Friday
         )
 
-        parser.timetableItems.forEachIndexed { index, itemsOfDay ->
-            val codes = itemsOfDay.map { it.code }
+        timetable!!.days.forEachIndexed {index, day ->
+            val codes = timetable!!.days[index].items.map { it.code }
             assertTrue(expected[index].containsAll(codes))
-            assertEquals(expected[index].size, itemsOfDay.size)
+            assertEquals(expected[index].size, timetable!!.days[index].items.size)
         }
     }
 }


### PR DESCRIPTION
Instead of using arrays, lists etc. there are now classes that store a timetable.

**Timetable** is the main class, it stores 5 **TimetableDay** objects. Each **TimetableDay** object has a list of items (lectures, tutorials etc.)

**Timetable** also stores a SHA-256 hash of the document from which it was parsed. This is to allow checking if there were any changes made to the timetable (future functionality)