### PR TITLE
Add "Delete all" option in the timetables menu

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -36,14 +36,14 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'androidx.appcompat:appcompat:1.1.0'
-    implementation 'androidx.core:core-ktx:1.2.0-beta02'
+    implementation 'androidx.core:core-ktx:1.2.0-rc01'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
-    implementation 'com.google.android.material:material:1.2.0-alpha01'
+    implementation 'com.google.android.material:material:1.2.0-alpha02'
     implementation 'joda-time:joda-time:2.10.5'
     implementation 'org.jsoup:jsoup:1.12.1'
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation "org.jetbrains.kotlinx:kotlinx-serialization-runtime:0.13.0"
     testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'androidx.test:runner:1.3.0-alpha02'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0-alpha02'
+    androidTestImplementation 'androidx.test:runner:1.3.0-alpha03'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0-alpha03'
 }

--- a/app/src/main/java/com/example/hwutimetable/filehandler/DocumentHandler.kt
+++ b/app/src/main/java/com/example/hwutimetable/filehandler/DocumentHandler.kt
@@ -84,6 +84,19 @@ object DocumentHandler {
     }
 
     /**
+     * Deletes all timetables stored on the device
+     * @return List of the deleted timetables
+     */
+    fun deleteAllTimetables(context: Context): List<TimetableInfo> {
+        val deleted = mutableListOf<TimetableInfo>()
+        InfoFile.getList(context).forEach {
+            if (deleteTimetable(context, it.name))
+                deleted.add(it)
+        }
+        return deleted
+    }
+
+    /**
      * Adds the .html suffix to the timetable code taken from [info]
      */
     private fun getFilenameByInfo(info: TimetableInfo): String {

--- a/app/src/main/res/menu/menu_main.xml
+++ b/app/src/main/res/menu/menu_main.xml
@@ -6,4 +6,8 @@
           android:title="@string/action_settings"
           android:orderInCategory="100"
           app:showAsAction="never"/>
+    <item android:id="@+id/action_delete"
+          android:title="@string/delete_all"
+          android:orderInCategory="101"
+          app:showAsAction="never"/>
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,4 +7,5 @@
 	<string name="submit">Get Timetable</string>
 	<string name="no_timetables">No timetables found</string>
 	<string name="title_activity_view_timetable">View Timetable</string>
+    <string name="delete_all">Delete all</string>
 </resources>


### PR DESCRIPTION
By using the menu on the main activity (screen) the users can now delete all timetables that are stored on the device.
Part of enhancement "issue" #16 