### PR TITLE
Fix Parcelable Bug by implementing Parcelable explicitly

### DIFF
--- a/app/src/main/java/com/example/hwutimetable/parser/TimetableItem.kt
+++ b/app/src/main/java/com/example/hwutimetable/parser/TimetableItem.kt
@@ -1,8 +1,7 @@
 package com.example.hwutimetable.parser
 
+import android.os.Parcel
 import android.os.Parcelable
-import kotlinx.android.parcel.Parcelize
-import kotlinx.android.parcel.RawValue
 import org.joda.time.LocalTime
 import org.joda.time.Minutes
 import org.joda.time.Period
@@ -10,15 +9,51 @@ import org.joda.time.Period
 /**
  * TimetableItem object represents a lecture, lab, tutorial etc.
  */
-@Parcelize
-data class TimetableItem(
+open class TimetableItem(
     val code: String,
     val name: String,
     val room: String,
     val lecturer: String,
-    val type: @RawValue ItemType,
+    val type: ItemType,
     val start: LocalTime,
     val end: LocalTime,
     val weeks: String,
     val duration: Period = Period.minutes(Minutes.minutesBetween(start, end).minutes)) : Parcelable {
+
+    constructor(parcel: Parcel) : this(
+        code = parcel.readString()!!,
+        name = parcel.readString()!!,
+        room = parcel.readString()!!,
+        lecturer = parcel.readString()!!,
+        type = ItemType(parcel.readString()!!),
+        start = LocalTime.parse(parcel.readString()),
+        end = LocalTime.parse(parcel.readString()),
+        weeks = parcel.readString()!!
+    )
+
+    override fun writeToParcel(dest: Parcel?, flags: Int) {
+        dest ?: return
+        with(dest) {
+            writeString(code)
+            writeString(name)
+            writeString(room)
+            writeString(lecturer)
+            writeString(type.name)
+            writeString(start.toString())
+            writeString(end.toString())
+            writeString(weeks)
+        }
+    }
+
+    override fun describeContents() = 0
+
+    companion object CREATOR : Parcelable.Creator<TimetableItem> {
+        override fun createFromParcel(parcel: Parcel): TimetableItem {
+            return TimetableItem(parcel)
+        }
+
+        override fun newArray(size: Int): Array<TimetableItem?> {
+            return arrayOfNulls(size)
+        }
+    }
 }


### PR DESCRIPTION
The parcelable bug as described in the issue #21 crashed the app whenever the users used "Recent Apps" or "Home" on the timetable view. This is probably due to the unserializable objects like `LocalTime` or `ItemType` in the `TimetableItem` class.

The fix fixes that bug by implementing the `Parcelable` interface explicitly where the parcel contains string versions of the different variables of the Item class.