### PR TITLE
Updater fix

### DIFF
--- a/app/src/main/java/com/example/hwutimetable/parser/Parser.kt
+++ b/app/src/main/java/com/example/hwutimetable/parser/Parser.kt
@@ -13,14 +13,12 @@ import org.jsoup.nodes.Element
  * use [getTimetable] to get the parsed timetable.
  */
 class Parser : TimetableParser {
-    private val timetableDays: Array<TimetableDay> = arrayOf(
-        TimetableDay(Day.MONDAY, arrayListOf()),
-        TimetableDay(Day.TUESDAY, arrayListOf()),
-        TimetableDay(Day.WEDNESDAY, arrayListOf()),
-        TimetableDay(Day.THURSDAY, arrayListOf()),
-        TimetableDay(Day.FRIDAY, arrayListOf())
-    )
+    private lateinit var timetableDays: Array<TimetableDay>
     private lateinit var document: Document
+
+    init {
+        initTimetableDays()
+    }
 
     /**
      * Finds the rows of the day and returns the list of them
@@ -183,7 +181,18 @@ class Parser : TimetableParser {
      */
     override fun setDocument(document: Document): Parser {
         this.document = document
+        initTimetableDays()
         return this
+    }
+
+    private fun initTimetableDays() {
+        this.timetableDays = arrayOf(
+            TimetableDay(Day.MONDAY, arrayListOf()),
+            TimetableDay(Day.TUESDAY, arrayListOf()),
+            TimetableDay(Day.WEDNESDAY, arrayListOf()),
+            TimetableDay(Day.THURSDAY, arrayListOf()),
+            TimetableDay(Day.FRIDAY, arrayListOf())
+        )
     }
 
     /**

--- a/app/src/main/java/com/example/hwutimetable/scraper/Scraper.kt
+++ b/app/src/main/java/com/example/hwutimetable/scraper/Scraper.kt
@@ -67,7 +67,7 @@ class Scraper : TimetableScraper {
      * @return status code after transition
      */
     fun goToProgrammesTimetables(): Int {
-        check(state == ScraperState.LoggedIn) {
+        if (state != ScraperState.LoggedIn && state != ScraperState.Finished) {
             throw IllegalStateException("Cannot perform this action when not logged in")
         }
 
@@ -226,8 +226,12 @@ class Scraper : TimetableScraper {
      * @return HTML document with the timetable
      */
     override fun getTimetable(group: String, semester: Int): Document {
-        if (state == ScraperState.Finished)
-            return response as Document  // We have finished scraping - result is the timetable
+        if (state == ScraperState.Finished) {
+            cookies.clear()
+            response = null
+            login()
+            goToProgrammesTimetables()
+        }
 
         // We have to apply filters even though we know the group option value
         // Otherwise we will get an error "No items have been selected for your request"

--- a/app/src/main/java/com/example/hwutimetable/updater/UpdateService.kt
+++ b/app/src/main/java/com/example/hwutimetable/updater/UpdateService.kt
@@ -12,6 +12,8 @@ import androidx.preference.PreferenceManager
 import com.example.hwutimetable.filehandler.TimetableInfo
 import com.example.hwutimetable.parser.Parser
 import com.example.hwutimetable.scraper.Scraper
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
 
 /**
  * [UpdateService] is a service that is responsible for starting the update process the timetables stored on the device
@@ -34,17 +36,18 @@ class UpdateService : Service(), UpdateNotificationReceiver {
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-        configurePerformer(intent)
-        configureNotifier(intent)
-        registerSelfAsReceiver()
+        GlobalScope.launch {
+            configurePerformer(intent)
+            configureNotifier(intent)
+            registerSelfAsReceiver()
 
-        if (canUpdate()) {
-            Log.i(logTag, "Update alarm has been triggered, starting the update process")
-            updater.update()
-        } else {
-            Log.i(logTag, "Update alarm has been triggered but was no allowed transport method was available.")
+            if (canUpdate()) {
+                Log.i(logTag, "Update alarm has been triggered, starting the update process")
+                updater.update()
+            } else {
+                Log.i(logTag, "Update alarm has been triggered but was no allowed transport method was available.")
+            }
         }
-
         return START_STICKY
     }
 

--- a/app/src/main/res/drawable/cw_background.xml
+++ b/app/src/main/res/drawable/cw_background.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape
+        android:id="@+id/lec_background"
+        android:shape="rectangle"
+        xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:id="@+id/background" android:color="#FF80FF"/>
+    <stroke android:color="#000000" android:width="1dp"/>
+</shape>


### PR DESCRIPTION
The fix fixes the following:
- When reusing scraper it returned the first scraped timetable.
- NetworkOnMainThreadException as described in the issue #33 
- Timetables get combined when reusing the same parser
- No CW-type background throwing  NotFoundException