### PR TITLE
Fix update alarm triggering instantly

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -21,7 +21,7 @@
 	<!-- Preference keys -->
 	<string name="wifi_pref_key">allow_wifi</string>
 	<string name="data_pref_key">allow_data</string>
-	<string name="time_pref_key">time</string>
-	<string name="frequency_pref_key">frequency</string>
+	<string name="time_pref_key">time_preference</string>
+	<string name="frequency_pref_key">frequency_preference</string>
 	<string name="updates_pref_key">enable_updates</string>
 </resources>


### PR DESCRIPTION
The update alarm got triggered instantly after opening the Update Settings. This was due to the fact that the alarm was set right after creating the `UpdateManager` object, without reading and setting the user settings. This issue was fixed.

Another issue that this PR fixes is that alarm also got triggered immediately when the time was set in the past. This happened when, for instance it was 1pm and the alarm was set for 6am.