### PR TITLE
Fix wrong alarm time

### DIFF
--- a/app/src/main/java/com/example/hwutimetable/updater/UpdateManager.kt
+++ b/app/src/main/java/com/example/hwutimetable/updater/UpdateManager.kt
@@ -86,7 +86,7 @@ internal class UpdateManager(private val context: Context) :
 
         val currentTime = calendar.timeInMillis
         var triggerTime = calendar.apply {
-            set(Calendar.HOUR, hourOfDay)
+            set(Calendar.HOUR_OF_DAY, hourOfDay)
             set(Calendar.MINUTE, minuteOfHour)
         }.timeInMillis
 


### PR DESCRIPTION
The UpdateManager was setting wrong field of the calendar - `HOUR` instead of `HOUR_OF_DAY`