### PR TITLE
Add IntRangeExtension Test

### DIFF
--- a/app/src/test/java/com/example/hwutimetable/extensions/IntRangeExtensionsTest.kt
+++ b/app/src/test/java/com/example/hwutimetable/extensions/IntRangeExtensionsTest.kt
@@ -1,0 +1,22 @@
+package com.example.hwutimetable.extensions
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Test
+
+class IntRangeExtensionsTest {
+    @Test
+    fun testRange() {
+        val expected = intArrayOf(-2, -1, 0, 1, 2, 3)
+        val actual = (-2..3).toIntArray()
+
+        assertArrayEquals(expected, actual)
+    }
+
+    @Test
+    fun testInvalidRange() {
+        val expected = IntArray(0)
+        @Suppress("EmptyRange") val actual = (5..1).toIntArray()
+
+        assertArrayEquals(expected, actual)
+    }
+}

--- a/app/src/test/java/com/example/hwutimetable/filehandler/TimetableFileHandlerTest.kt
+++ b/app/src/test/java/com/example/hwutimetable/filehandler/TimetableFileHandlerTest.kt
@@ -11,7 +11,7 @@ import org.junit.Test
 import java.io.File
 import java.io.FileNotFoundException
 
-class TestTimetableFileHandler {
+class TimetableFileHandlerTest {
     companion object {
         private val dir_path: String = System.getProperty("user.dir") + "/tfh_test_dir"
         private val test_dir = File(dir_path)

--- a/app/src/test/java/com/example/hwutimetable/parser/WeeksBuilderTest.kt
+++ b/app/src/test/java/com/example/hwutimetable/parser/WeeksBuilderTest.kt
@@ -5,7 +5,7 @@ import com.example.hwutimetable.parser.exceptions.InvalidRangeException
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
-class TestWeeksBuilder {
+class WeeksBuilderTest {
     @Test
     fun testSetRange() {
         val weeks = WeeksBuilder()

--- a/app/src/test/java/com/example/hwutimetable/parser/WeeksTest.kt
+++ b/app/src/test/java/com/example/hwutimetable/parser/WeeksTest.kt
@@ -4,7 +4,7 @@ import com.example.hwutimetable.extensions.toIntArray
 import org.junit.Assert.*
 import org.junit.Test
 
-class TestWeeks {
+class WeeksTest {
     @Test
     fun testDurationOneWeek() {
         val weeks = Weeks(intArrayOf(1))


### PR DESCRIPTION
Custom IntRange extension - `toIntArray` changes a range to an int array. No tests existed for it, this PR adds two simple ones.

The PR also renames some test files to match the form {classname}Test