### PR TITLE
Change text colour to white in timetable view

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,7 +14,7 @@ android {
         minSdkVersion 23
         targetSdkVersion 29
         versionCode 1
-        versionName "1.0"
+        versionName "0.7"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     buildTypes {

--- a/app/src/main/java/com/example/hwutimetable/TimetableView.kt
+++ b/app/src/main/java/com/example/hwutimetable/TimetableView.kt
@@ -2,6 +2,7 @@ package com.example.hwutimetable
 
 import android.annotation.SuppressLint
 import android.content.Context
+import android.graphics.Color
 import android.graphics.drawable.Drawable
 import android.view.Gravity
 import android.view.View
@@ -234,6 +235,7 @@ object TimetableView {
             this.height = getTimeLabelHeight(context)
             this.width = 0
             this.gravity = gravity
+            this.setTextColor(Color.WHITE)
         }
     }
 


### PR DESCRIPTION
The black text colour was unreadable, especially on darker backgrounds. This PR changes the colour to white, drastically improving readability.