### PR TITLE
Add Activity - minor fixes

### DIFF
--- a/app/src/main/java/com/example/hwutimetable/AddActivity.kt
+++ b/app/src/main/java/com/example/hwutimetable/AddActivity.kt
@@ -3,6 +3,7 @@ package com.example.hwutimetable
 import android.app.ActivityOptions
 import android.content.Intent
 import android.os.Bundle
+import android.view.MenuItem
 import android.view.View
 import android.widget.AdapterView
 import android.widget.ArrayAdapter
@@ -38,8 +39,20 @@ class AddActivity : AppCompatActivity(), AdapterView.OnItemSelectedListener {
         setItemSelectedListener()
         setButtonClickListener()
 
+        supportActionBar!!.setDisplayHomeAsUpEnabled(true)
+        setTitle(R.string.add_activity_title)
+
         mainScope.launch {
             populateDepartmentsAndLevels()
+        }
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        return when (item.itemId) {
+            android.R.id.home -> {
+                onBackPressed(); true
+            }
+            else -> return super.onOptionsItemSelected(item)
         }
     }
 

--- a/app/src/main/java/com/example/hwutimetable/MainActivity.kt
+++ b/app/src/main/java/com/example/hwutimetable/MainActivity.kt
@@ -48,6 +48,7 @@ class MainActivity : AppCompatActivity(), NetworkUtilities.ConnectivityCallbackR
 
         fab.setOnClickListener {
             val intent = Intent(this, AddActivity::class.java)
+            intent.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY)
             startActivity(intent, ActivityOptions.makeSceneTransitionAnimation(this).toBundle())
         }
         fab.backgroundTintList = applicationContext.getColorStateList(R.color.fab_color)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,6 @@
 <resources>
 	<string name="app_name">HWU Timetable</string>
+	<string name="add_activity_title">Add Timetable</string>
 	<string name="action_settings">Settings</string>
 	<string name="departments">Departments:</string>
 	<string name="levels">Levels:</string>


### PR DESCRIPTION
- Added title
- Added back arrow that takes user to previous activity
- `AddActivity` does not get added to `Activity` history. This means that when user goes through `MainActivity`->`AddActivity`->`ViewTimetable` then upon pressing return, they will go back to the `MainActivity`.