### PR TITLE
README update + removed "Follow" from AddActivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,40 +5,30 @@ HWU Timetable or in full Heriot Watt University Timetable is an **unofficial** A
 easier to view student timetables on a mobile device.
 
 ## What is it and why it exists?
-The student timetable website is not mobile friendly. The aim of this project is to not only change that, 
-but also provide some of the functionalities that will make student's life at the University easier.
+The student timetable website is not mobile friendly, which is quite a big issue considering how students are encouraged
+to check their timetables regularly. The aim of this project is to make accessing timetables much easier, and bring some
+other useful functionalities.
 
-The app allows you to add a timetable to "followed", this saves it locally on your device so you can view it
-at any time and place you want without having to be connected to the Internet. 
+The app allows you to save a timetable to your Android device and be notified of any changes that are made to it, by
+automatically checking for differences between the saved timetable and the online one. Frequency of these checks depends
+on the settings.
 
-The word choice of "followed" is deliberate. The app will check the website regularly to see if there are any updates
-to the timetables that are stored on the device. If there are, the app will download the newest version of every
-timetable and notify you about the update.
 ## Current state of the project
-The app, at this stage, is still far from being ready to be deployed.
-
-Currently, the main focus goes on implementing the core functionality rather than User Experience. At the current state
-the app may go through many major changes from one update to another without giving any notice, therefore it is strongly
-recommended that (assuming you are interested) you stay patient until the app will be considered ready to be deployed.
-
-Functionalities that have been implemented so far are:
-- Saving a timetable to the device
-- Viewing the parsed timetable in a very simple form
-- Updating the stored timetables based on user preferences (in settings)
-- Detecting clashes and notifying the user about them
-
+The project is now at the stage where the majority of desired functionalities have been implemented and tested by
+automated tests. There are a few functionalities that would be nice to have, however currently, the focus is to enhance
+User Experience. If you would like to know what functionalities will be implemented in the future, please check the 
+"Issues".
 ## Using the app
-First, you will see the empty screen. The majority of the screen is blank, this is actually a list of the stored 
-timetables. You will see how it works after we add the first timetable.
+First, you will see the screen shown below. All the stored timetables will be shown here, but since you do not have any
+at the moment, use the "Add Button" to add one. 
 
-![main_empty](https://user-images.githubusercontent.com/23484014/72175465-1fee0f80-33d4-11ea-9840-36d39d6de7a2.png)
+![main_empty](https://user-images.githubusercontent.com/23484014/88577282-ab608280-d03e-11ea-8c13-ac0632e17781.png)
 
 
-Click the circle add button to add your timetable. This will take you to another screen where you need to choose
-the department, the level and the group. There is no need to choose the semester like on the website - this will
-be done automatically by the app.
+This will take you to another screen where you need to choose the department, the level and the group. There is no need 
+to choose the semester like on the website - this will be done automatically by the app.
 
-![adding](https://user-images.githubusercontent.com/23484014/72175464-1fee0f80-33d4-11ea-855f-8f695356961c.png)
+![adding](https://user-images.githubusercontent.com/23484014/88577279-aac7ec00-d03e-11ea-9f67-3eed41750213.png)
 
 
 After adding the timetable, you will be taken to the timetable view. Here you see your timetable, there are a couple
@@ -48,17 +38,15 @@ of features that were implemented into the app so please read the following care
 
 
 The displayed day depends on the current day. That is, if you are viewing the timetable on Wednesday, the app will
-automatically go to Wednesday items. To view a different day, simply swipe left or right, or you can also click on the
-previous or next day.
+automatically go to Wednesday lectures/labs. To view a different day, simply swipe left or right, or you can also click 
+on the previous/next day label at the top of the screen.
 
-The same goes for weeks, you can select weeks above the timetable view. By default, you will see the timetable
-for the current week.
+The same goes for weeks, by default you will see the timetable for the current week. You can choose a different week
+using the dropdown at the top of the screen.
 
 Now, if you go back to the main view you will see that the list has been populated with the recently added timetable.
 
-![main_wcontent](https://user-images.githubusercontent.com/23484014/72175466-1fee0f80-33d4-11ea-84f8-e7a13f4d7516.png)
-
-The circle appearing beside the name indicates the semester of the timetable.
+![main_wcontent](https://user-images.githubusercontent.com/23484014/88577283-ab608280-d03e-11ea-8ff8-4b76437710f3.png)
 
 ### Update checks
 To enable update checks, go into settings by clicking the so-called "kebab menu" or "overflow menu" go into settings 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,7 +10,7 @@
 	<string name="no_timetables">No timetables found</string>
 	<string name="title_activity_view_timetable">View Timetable</string>
 	<string name="delete_all">Delete all</string>
-	<string name="follow">Save on the device and \"follow\"</string>
+	<string name="follow">Save on the device</string>
 	<string name="viewing_week">Select Week:</string>
 	<string name="update_notification_channel_name">Update notifications</string>
 	<string name="update_notification_channel_desc">


### PR DESCRIPTION
README has been updated as it was out of date. 
Removed the term "to follow" a timetable from README as well as the `AddActivity` as it was not clear what it means.