### PR TITLE
Linguist and .gitignore fixes.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
-# Exclude HTML files from language stats
+# Exclude HTML and CSS files from language stats
 *.html linguist-vendored
+*.css linguist-vendored

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /captures
 .externalNativeBuild
 /build/
+release/


### PR DESCRIPTION
Exclude CSS from languages list
Update .gitignore to ignore any `release` directory.