### PR TITLE
Return next week on the weekend

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,8 @@ before_script:
   - adb shell settings put global window_animation_scale 0 &
   - adb shell settings put global transition_animation_scale 0 &
   - adb shell settings put global animator_duration_scale 0 &
-  - adb shell input keyevent 82 &
 
 script:
   - ./gradlew build assembleDebug
+  - adb shell input keyevent 82 &
   - travis_wait 20 ./gradlew connectedAndroidTest

--- a/app/src/main/java/com/github/hwutimetable/parser/Semester.kt
+++ b/app/src/main/java/com/github/hwutimetable/parser/Semester.kt
@@ -2,6 +2,7 @@ package com.github.hwutimetable.parser
 
 import android.os.Parcelable
 import kotlinx.android.parcel.Parcelize
+import org.joda.time.DateTimeConstants
 import org.joda.time.LocalDate
 import org.joda.time.Weeks
 import java.io.Serializable
@@ -17,10 +18,15 @@ data class Semester(val startDate: LocalDate, val number: Int) : Parcelable, Ser
      */
     fun getWeek(date: LocalDate): Int {
         val weeks = Weeks.weeksBetween(startDate, date).weeks + 1
+        /* dayOfWeek is an integer, where days of week are numbered from 1 (Monday) to 7 (Sunday).
+         * Therefore, we can check if the day of week is greater than, or equal to 6 (Saturday),
+         * and that will include Sunday as well.
+         */
+        val isWeekend = date.dayOfWeek >= DateTimeConstants.SATURDAY
         return when {
-            weeks <= 1 -> 1
-            weeks >= 12 -> 12
-            else -> weeks
+            weeks < 1 -> 1
+            weeks < 12 -> weeks + if (isWeekend) 1 else 0
+            else -> 12
         }
     }
 

--- a/app/src/test/java/com/github/hwutimetable/parser/SemesterTest.kt
+++ b/app/src/test/java/com/github/hwutimetable/parser/SemesterTest.kt
@@ -31,4 +31,26 @@ class SemesterTest {
 
         assertEquals(5, week)
     }
+
+    /**
+     * This test will check if during the weekend, the next week will be returned.
+     */
+    @Test
+    fun testReturnsNextWeekOnSaturday() {
+        val saturday = LocalDate(2020, 1, 18)
+        val week = semester.getWeek(saturday)
+
+        assertEquals(2, week)
+    }
+
+    /**
+     * This test will check if during the weekend, the next week will be returned.
+     */
+    @Test
+    fun testReturnsNextWeekOnSunday() {
+        val sunday = LocalDate(2020, 1, 19)
+        val week = semester.getWeek(sunday)
+
+        assertEquals(2, week)
+    }
 }

--- a/app/src/test/java/com/github/hwutimetable/parser/SemesterTest.kt
+++ b/app/src/test/java/com/github/hwutimetable/parser/SemesterTest.kt
@@ -17,8 +17,24 @@ class SemesterTest {
     }
 
     @Test
+    fun testGetFirstWeekBeforeSemesterStarts() {
+        val currentDate = LocalDate(2020, 1, 1)
+        val week = semester.getWeek(currentDate)
+
+        assertEquals(1, week)
+    }
+
+    @Test
     fun testGetLastWeek() {
         val currentDate = LocalDate(2020, 4, 5)
+        val week = semester.getWeek(currentDate)
+
+        assertEquals(12, week)
+    }
+
+    @Test
+    fun testGetLastWeekAfterSemesterEnds() {
+        val currentDate = LocalDate(2020, 5, 1)
         val week = semester.getWeek(currentDate)
 
         assertEquals(12, week)


### PR DESCRIPTION
When checking the timetable during the weekend, return the next week instead of the current (past) one.