### PR TITLE
Timetable delete from new context menu

### DIFF
--- a/app/src/androidTest/java/com/github/hwutimetable/MainActivityTest.kt
+++ b/app/src/androidTest/java/com/github/hwutimetable/MainActivityTest.kt
@@ -313,7 +313,6 @@ class MainActivityTest {
         Intents.release()
     }
 
-
     @Test
     fun testDeleteAllDisplaysAlertDialog() {
         launchActivity()
@@ -366,6 +365,7 @@ class MainActivityTest {
         launchActivity()
 
         Espresso.onView(withText("Timetable 2")).perform(longClick())
+        Espresso.onView(withText(targetContext.getString(R.string.item_context_menu_rename))).perform(click())
         Espresso.onView(withText(targetContext.getString(R.string.rename_dialog_title))).check(matches(isDisplayed()))
     }
 
@@ -375,6 +375,7 @@ class MainActivityTest {
         launchActivity()
 
         Espresso.onView(withText("Timetable 2")).perform(longClick())
+        Espresso.onView(withText(targetContext.getString(R.string.item_context_menu_rename))).perform(click())
         Espresso.onView(withText("Cancel")).perform(click())
         Espresso.onView(withText(targetContext.getString(R.string.rename_dialog_title))).check(doesNotExist())
     }
@@ -385,6 +386,7 @@ class MainActivityTest {
         launchActivity()
 
         Espresso.onView(withText("Timetable 2")).perform(longClick())
+        Espresso.onView(withText(targetContext.getString(R.string.item_context_menu_rename))).perform(click())
         Espresso.onView(withId(R.id.edit_timetable_title)).perform(clearText(), typeText("Renamed Timetable"))
         Espresso.onView(withText("Rename")).perform(click())
 
@@ -397,6 +399,7 @@ class MainActivityTest {
         launchActivity()
 
         Espresso.onView(withText("Timetable 2")).perform(longClick())
+        Espresso.onView(withText(targetContext.getString(R.string.item_context_menu_rename))).perform(click())
         Espresso.onView(withId(R.id.edit_timetable_title)).perform(clearText(), typeText("Renamed Timetable"))
         Espresso.onView(withText("Rename")).perform(click())
 

--- a/app/src/androidTest/java/com/github/hwutimetable/MainActivityTest.kt
+++ b/app/src/androidTest/java/com/github/hwutimetable/MainActivityTest.kt
@@ -369,6 +369,38 @@ class MainActivityTest {
     }
 
     @Test
+    fun testContextMenuAppears() {
+        populateInfoList()
+        launchActivity()
+
+        Espresso.onView(withText("Timetable 1")).perform(longClick())
+        Espresso.onView(withText(R.string.item_context_menu_title))
+            .check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun testContextMenuCancel() {
+        populateInfoList()
+        launchActivity()
+
+        Espresso.onView(withText("Timetable 1")).perform(longClick())
+        Espresso.onView(withId(android.R.id.button1)).perform(click())
+        Espresso.onView(withText(R.string.item_context_menu_title)).check(doesNotExist())
+    }
+
+    @Test
+    fun testDeleteByContextMenu() {
+        populateInfoList()
+        launchActivity()
+        val timetableToDelete = "Timetable 2"
+        Espresso.onView(withText(timetableToDelete)).perform(longClick())
+        Espresso.onView(withText(R.string.item_context_menu_delete)).perform(click())
+
+        // Check if deleted
+        assertNull(timetableFileHandler.getStoredTimetables().find { it.name == timetableToDelete })
+    }
+
+    @Test
     fun testRenameDialogPopsUp() {
         populateInfoList()
         launchActivity()

--- a/app/src/androidTest/java/com/github/hwutimetable/MainActivityTest.kt
+++ b/app/src/androidTest/java/com/github/hwutimetable/MainActivityTest.kt
@@ -314,6 +314,15 @@ class MainActivityTest {
     }
 
     @Test
+    fun testSwipeToDelete() {
+        populateInfoList()
+        launchActivity()
+
+        Espresso.onView(withText("Timetable 2")).perform(swipeLeft())
+        assertNull(timetableFileHandler.getStoredTimetables().find { it.name == "Timetable 2" })
+    }
+
+    @Test
     fun testDeleteAllDisplaysAlertDialog() {
         launchActivity()
         // Open menu

--- a/app/src/main/java/com/github/hwutimetable/ItemContextMenu.kt
+++ b/app/src/main/java/com/github/hwutimetable/ItemContextMenu.kt
@@ -1,0 +1,50 @@
+package com.github.hwutimetable
+
+import android.app.Activity
+import android.app.AlertDialog
+
+
+/**
+ * The [ItemContextMenu] is to be used when an item from the recycler view
+ * has been long-pressed.
+ * The menu contains entries for  performing different actions on selected
+ * timetable.
+ */
+class ItemContextMenu(private val activity: Activity) {
+    /**
+     * Represents the chosen action from the context menu
+     */
+    enum class Action {
+        RENAME,
+        DELETE,
+    }
+
+    /**
+     * Called when an action has been selected from the context menu.
+     * Does not include the cancel button - this is handled internally
+     * and dismisses the dialog.
+     */
+    fun interface OnActionClickedListener {
+        fun onActionClicked(action: Action)
+    }
+
+    /**
+     * Create the dialog for the context menu with populated options.
+     */
+    fun create(listener: OnActionClickedListener): AlertDialog {
+        return AlertDialog.Builder(activity).run {
+            setTitle(R.string.item_context_menu_title)
+            setItems(R.array.item_actions) { _, which ->
+                when (which) {
+                    0 -> listener.onActionClicked(Action.RENAME)
+                    1 -> listener.onActionClicked(Action.DELETE)
+                }
+            }
+            setPositiveButton(R.string.cancel) { dialog, _ ->
+                dialog.dismiss()
+            }
+            create()
+        }
+    }
+
+}

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -4,4 +4,9 @@
         <item name="semester_2">@string/semester_2</item>
         <item name="semester_any">@string/semester_any</item>
     </string-array>
+
+    <string-array name="item_actions">
+        <item name="rename">@string/item_context_menu_rename</item>
+        <item name="delete">@string/item_context_menu_delete</item>
+    </string-array>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,6 +11,10 @@
     <string name="no_timetables">No timetables found</string>
     <string name="delete_all">Delete all</string>
     <string name="delete_all_confirmation">Are you sure?</string>
+    <!-- Timetable item context menu dialog -->
+    <string name="item_context_menu_title">Choose action</string>
+    <string name="item_context_menu_rename">Rename</string>
+    <string name="item_context_menu_delete">Delete</string>
 
     <!-- Add Programme Timetable Activity -->
     <string name="departments">Department:</string>
@@ -130,4 +134,7 @@
     </string>
     <string name="setup_timetable_programme">Otherwise, to add a timetable for your programme, click the button below
     </string>
+
+    <!-- Misc -->
+    <string name="cancel">Cancel</string>
 </resources>

--- a/app/src/main/res/xml/changelog.xml
+++ b/app/src/main/res/xml/changelog.xml
@@ -1,4 +1,7 @@
 <changelog>
+    <version versionCode="5" versionName="0.9RC2">
+        <change>Added context menu on timetable long click.</change>
+    </version>
     <version versionCode="4" versionName="0.9RC1">
         <change>Fixed an issue with minimising the app in Add Timetable/Add Course.</change>
         <change>Added Change Log</change>


### PR DESCRIPTION
Created new `ItemContextMenu` that appears on a long press on a timetable (item from the list).
This replaces the rename dialog that appeared originally, now it's available from the menu, which also contains a delete option.